### PR TITLE
add execution permission for created dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 			continue
 		}
 
-		err = os.Mkdir(output, 0644)
+		err = os.Mkdir(output, 0755)
 		if err != nil {
 			color.HiRed("* Failed to create a folder for %s. Skipping. (%s)", f.Name(), err.Error())
 			continue


### PR DESCRIPTION
A dir must be executable. Otherwise, you cannot read or write files inside it.

See: https://superuser.com/a/169418/1418734